### PR TITLE
Support response objects from ViewerRequest and OriginRequest

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -573,9 +573,11 @@ function payloadVerifyResponse(payload) {
 	}
 
 	// confirm expected properties exist
-	payloadVerifyPropertyHeaders(payload,'headers');
 	payloadPropertyExistsString(payload,'status');
-	payloadPropertyExistsString(payload,'statusDescription');
+
+	// confirm optional properties have the right type:
+	if ('headers' in payload) payloadVerifyPropertyHeaders(payload,'headers');
+	if ('statusDescription' in payload) payloadPropertyExistsString(payload,'statusDescription');
 
 	// ensure `payload.status` is a valid/known HTTP status code
 	if (!HTTP_STATUS_CODE_DESCRIPTION.hasOwnProperty(payload.status)) {

--- a/main.js
+++ b/main.js
@@ -9,7 +9,15 @@ class ViewerRequest extends lib.EdgeEventRequestBase {
 	}
 
 	_payloadVerify(payload) {
-		lib.payloadVerifyRequest(payload);
+		if ('status' in payload) {
+			// A payload with a 'status' key means the request handler yielded a
+			// response object (short-circuiting the origin):
+			lib.payloadVerifyResponse(payload);
+		} else {
+			// A payload without a 'status' key means the request handler yielded
+			// a request object headed for the origin:
+			lib.payloadVerifyRequest(payload);
+		}
 	}
 }
 
@@ -70,8 +78,16 @@ class OriginRequest extends lib.EdgeEventRequestBase {
 	}
 
 	_payloadVerify(payload) {
-		lib.payloadVerifyRequest(payload);
-		lib.payloadVerifyRequestOrigin(payload);
+		if ('status' in payload) {
+			// A payload with a 'status' key means the request handler yielded a
+			// response object (short-circuiting the origin):
+			lib.payloadVerifyResponse(payload);
+		} else {
+			// A payload without a 'status' key means the request handler yielded
+			// a request object headed for the origin:
+			lib.payloadVerifyRequest(payload);
+			lib.payloadVerifyRequestOrigin(payload);
+		}
 	}
 }
 

--- a/test/main-payloadverify.test.js
+++ b/test/main-payloadverify.test.js
@@ -855,7 +855,7 @@ function testPayloadVerifyResponse(inst) {
 	assert.throws(function() { callVerify(undefined); });
 
 	// test: payload missing/invalid property values
-	assert.throws(function() {
+	assert.doesNotThrow(function() {
 		callVerify(makePayload(function(payload) {
 			delete payload.headers;
 		}));
@@ -949,7 +949,7 @@ function testPayloadVerifyResponse(inst) {
 		}));
 	});
 
-	assert.throws(function() {
+	assert.doesNotThrow(function() {
 		callVerify(makePayload(function(payload) {
 			delete payload.statusDescription;
 		}));


### PR DESCRIPTION
Following issue #4, this PR adds a `status` property check to `_verifyPayload` in `ViewerRequest` and `OriginRequest` to dispatch to either a request or response verifier. Switching to a response verified adds support for request function handlers to yield a valid response object when short-circuiting the origin.

This PR also relaxes the required properties `statusDescription` and `headers` as optional in response objects.